### PR TITLE
Handle Pinterest links as images

### DIFF
--- a/src/app/api/pinterest/route.ts
+++ b/src/app/api/pinterest/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { url } = await req.json();
+    if (!url) {
+      return NextResponse.json({ error: 'URL is required' }, { status: 400 });
+    }
+
+    const resp = await fetch(url);
+    const html = await resp.text();
+
+    const imageMatch = html.match(/<meta[^>]*property=["']og:image["'][^>]*content=["']([^"']+)["']/i);
+    const titleMatch = html.match(/<meta[^>]*property=["']og:title["'][^>]*content=["']([^"']+)["']/i);
+    const imageUrl = imageMatch ? imageMatch[1] : null;
+    const title = titleMatch ? titleMatch[1] : null;
+
+    if (!imageUrl) {
+      return NextResponse.json({ error: 'Image not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ imageUrl, title });
+  } catch (error: any) {
+    console.error('Pinterest Parse Error:', error);
+    return NextResponse.json({ error: 'Failed to fetch pin', message: error.message }, { status: 500 });
+  }
+}

--- a/src/lib/pinterest.ts
+++ b/src/lib/pinterest.ts
@@ -1,0 +1,19 @@
+export interface PinterestData {
+  imageUrl: string | null;
+  title: string | null;
+}
+
+export async function getPinterestImage(url: string): Promise<PinterestData> {
+  try {
+    const res = await fetch('/api/pinterest', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url })
+    });
+    if (!res.ok) throw new Error('Failed to fetch Pinterest image');
+    return await res.json();
+  } catch (error) {
+    console.error('Failed to get Pinterest image', error);
+    return { imageUrl: null, title: null };
+  }
+}


### PR DESCRIPTION
## Summary
- add API route to scrape Pinterest og:image
- add helper function `getPinterestImage`
- handle Pinterest links in the artifact editor so they import as `image` instead of `article`

## Testing
- `next lint` *(fails: 403 Forbidden)*
- `tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68625f77a4ec833294e33bf95cec4b84